### PR TITLE
Add task to resolve all dependencies for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           key: jars-{{ checksum "checksums.txt" }}
       - run:
           name: Download dependencies
-          command: ./gradlew androidDependencies
+          command: ./gradlew resolveAllDependencies
       - save_cache:
           paths:
             - ~/.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import com.tylerkindy.github.Deps
+import com.tylerkindy.github.ResolveAllDependenciesTask
 
 buildscript {
     repositories {
@@ -46,6 +47,8 @@ allprojects {
         google()
         jcenter()
     }
+
+    task resolveAllDependencies(type: ResolveAllDependenciesTask)
 }
 
 task clean(type: Delete) {

--- a/buildSrc/src/main/java/com/tylerkindy/github/ResolveAllDependenciesTask.kt
+++ b/buildSrc/src/main/java/com/tylerkindy/github/ResolveAllDependenciesTask.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Tyler Kindy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tylerkindy.github
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+open class ResolveAllDependenciesTask : DefaultTask() {
+
+    @TaskAction
+    fun resolve() {
+        this.project.configurations
+                .filter { it.isCanBeResolved }
+                .forEach {
+                    it.resolve()
+                }
+    }
+}


### PR DESCRIPTION
This PR adds a custom Gradle task to resolve all dependencies manually. This is then used in a CI step to build up and store the Gradle cache to speed up future builds.