### PR TITLE
Add star and fork counts to repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle
 /local.properties
 /.idea/caches/build_file_checksums.ser
+/.idea/assetWizardSettings.xml
 /.idea/libraries
 /.idea/modules.xml
 /.idea/workspace.xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders = [ oauthToken: oauthToken ]
+        vectorDrawables.useSupportLibrary = true
     }
 }
 

--- a/app/src/main/graphql/com/tylerkindy/github/GitHubRepositoriesQuery.graphql
+++ b/app/src/main/graphql/com/tylerkindy/github/GitHubRepositoriesQuery.graphql
@@ -1,6 +1,6 @@
 query RepositoriesQuery {
   viewer {
-    repositories {
+    repositories(first: 25) {
       edges {
         node {
           id

--- a/app/src/main/graphql/com/tylerkindy/github/GitHubRepositoriesQuery.graphql
+++ b/app/src/main/graphql/com/tylerkindy/github/GitHubRepositoriesQuery.graphql
@@ -1,9 +1,16 @@
 query RepositoriesQuery {
   viewer {
-    repositories(first: 25) {
+    repositories {
       edges {
         node {
+          id
           name
+          forks {
+            totalCount
+          }
+          stargazers {
+            totalCount
+          }
         }
       }
     }

--- a/app/src/main/java/com/tylerkindy/github/network/GraphQLQueryException.kt
+++ b/app/src/main/java/com/tylerkindy/github/network/GraphQLQueryException.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Tyler Kindy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tylerkindy.github.network
+
+import com.apollographql.apollo.api.Error
+
+class GraphQLQueryException(
+  private val errors: Collection<Error>
+) : RuntimeException() {
+
+  override fun toString(): String {
+    return "${super.toString()}\n" +
+      errors.fold(StringBuilder()) { str, error ->
+        str.append(" ".repeat(6) + error.toString())
+      }
+        .toString()
+  }
+}

--- a/app/src/main/java/com/tylerkindy/github/ui/repolist/RepoItem.kt
+++ b/app/src/main/java/com/tylerkindy/github/ui/repolist/RepoItem.kt
@@ -1,17 +1,22 @@
 package com.tylerkindy.github.ui.repolist
 
 import com.tylerkindy.github.R
+import com.tylerkindy.github.RepositoriesQuery
 import com.xwray.groupie.kotlinandroidextensions.Item
 import com.xwray.groupie.kotlinandroidextensions.ViewHolder
 import kotlinx.android.synthetic.main.item_repo.*
 
-data class RepoItem(private val repoName: String) : Item() {
+data class RepoItem(
+  private val repo: RepositoriesQuery.Node
+) : Item() {
 
   override fun bind(viewHolder: ViewHolder, position: Int) {
-    viewHolder.repoName.text = repoName
+    viewHolder.repoName.text = repo.name()
+    viewHolder.repoStarCount.text = repo.stargazers().totalCount().toString()
+    viewHolder.repoForkCount.text = repo.forks().totalCount().toString()
   }
 
-  override fun getId() = repoName.hashCode().toLong()
+  override fun getId() = repo.id().hashCode().toLong()
 
   override fun getLayout() = R.layout.item_repo
 }

--- a/app/src/main/java/com/tylerkindy/github/ui/repolist/RepoListFragment.kt
+++ b/app/src/main/java/com/tylerkindy/github/ui/repolist/RepoListFragment.kt
@@ -11,7 +11,6 @@ import com.tylerkindy.github.ui.BaseFragment
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.Section
 import com.xwray.groupie.kotlinandroidextensions.ViewHolder
-import io.reactivex.android.schedulers.AndroidSchedulers
 import kotlinx.android.synthetic.main.fragment_repo_list.*
 
 class RepoListFragment : BaseFragment<RepoListViewModel>() {
@@ -25,13 +24,7 @@ class RepoListFragment : BaseFragment<RepoListViewModel>() {
     super.onCreate(savedInstanceState)
     viewModel = getModel()
 
-    val sub = viewModel.getRepos()
-      .map { response ->
-        response.data()?.viewer()?.repositories()?.edges()?.map {
-          RepoItem(it.node()?.name() ?: throw IllegalArgumentException("Name is null!"))
-        } ?: emptyList()
-      }
-      .observeOn(AndroidSchedulers.mainThread())
+    val sub = viewModel.getRepoItems()
       .subscribe(section::update)
 
     layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/com/tylerkindy/github/ui/repolist/RepoListViewModel.kt
+++ b/app/src/main/java/com/tylerkindy/github/ui/repolist/RepoListViewModel.kt
@@ -2,10 +2,11 @@ package com.tylerkindy.github.ui.repolist
 
 import androidx.lifecycle.ViewModel
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.rx2.Rx2Apollo
 import com.tylerkindy.github.RepositoriesQuery
+import com.tylerkindy.github.network.GraphQLQueryException
 import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 
@@ -13,12 +14,26 @@ class RepoListViewModel @Inject constructor(
   private val apolloClient: ApolloClient
 ) : ViewModel() {
 
-  fun getRepos(): Observable<Response<RepositoriesQuery.Data>> {
+  fun getRepoItems(): Observable<List<RepoItem>> {
     return Rx2Apollo.from(
       apolloClient.query(
         RepositoriesQuery.builder().build()
       )
     )
       .subscribeOn(Schedulers.io())
+      .map { response ->
+        if (response.hasErrors()) {
+          throw GraphQLQueryException(response.errors())
+        }
+
+        val repos = response.data()!!
+          .viewer()
+          .repositories()
+          .edges()
+          ?.mapNotNull(RepositoriesQuery.Edge::node) ?: emptyList()
+
+        repos.map(::RepoItem)
+      }
+      .observeOn(AndroidSchedulers.mainThread())
   }
 }

--- a/app/src/main/res/drawable/ic_star_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_star_black_24dp.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2018 Tyler Kindy
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/layout/item_repo.xml
+++ b/app/src/main/res/layout/item_repo.xml
@@ -26,4 +26,47 @@
         app:layout_constraintStart_toEndOf="@+id/repoImage"
         app:layout_constraintTop_toTopOf="@+id/repoImage"
         tools:text="tkindy.github.io" />
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="4dp"
+        app:layout_constraintBottom_toBottomOf="@+id/repoStarCount"
+        app:layout_constraintEnd_toStartOf="@+id/repoStarCount"
+        app:layout_constraintTop_toTopOf="@+id/repoStarCount"
+        app:srcCompat="@drawable/ic_star_black_24dp" />
+
+    <TextView
+        android:id="@+id/repoStarCount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="512" />
+
+    <TextView
+        android:id="@+id/repoForkCount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/repoStarCount"
+        tools:text="128" />
+
+    <ImageView
+        android:id="@+id/imageView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="4dp"
+        android:layout_marginBottom="-1dp"
+        app:layout_constraintBottom_toBottomOf="@+id/repoForkCount"
+        app:layout_constraintEnd_toStartOf="@+id/repoForkCount"
+        app:layout_constraintTop_toTopOf="@+id/repoForkCount"
+        app:srcCompat="@drawable/ic_star_black_24dp" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR adds the star and fork counts to each repository's listing. It also adds GraphQL error handling to the repository stream. I should be able to abstract this logic out for reuse across streams.